### PR TITLE
Filter history

### DIFF
--- a/src/qspdlog.cpp
+++ b/src/qspdlog.cpp
@@ -82,6 +82,8 @@ void QSpdLog::updateAutoScrollPolicy(int index) {
           }
         });
     break;
+  default:
+    break;
   }
 }
 

--- a/src/qspdlog_toolbar.cpp
+++ b/src/qspdlog_toolbar.cpp
@@ -5,6 +5,7 @@
 #include <qlayout>
 #include <qlineedit>
 #include <qregularexpression>
+#include <qsettings>
 #include <qstringlistmodel>
 
 QSpdLogToolBar::QSpdLogToolBar(QWidget *parent)
@@ -45,6 +46,7 @@ QSpdLogToolBar::QSpdLogToolBar(QWidget *parent)
       QModelIndex index = model->index(model->rowCount() - 1, 0);
       model->setData(index, text);
     }
+    saveCompleterHistory();
   });
   connect(_caseAction, &QAction::toggled, this, &QSpdLogToolBar::filterChanged);
   connect(_regexAction, &QAction::toggled, this,
@@ -54,6 +56,7 @@ QSpdLogToolBar::QSpdLogToolBar(QWidget *parent)
           &QSpdLogToolBar::autoScrollPolicyChanged);
   connect(this, &QSpdLogToolBar::filterChanged, this,
           &QSpdLogToolBar::checkInputValidity);
+  loadCompleterHistory();
 }
 
 QSpdLogToolBar::~QSpdLogToolBar() {}
@@ -84,4 +87,20 @@ void QSpdLogToolBar::checkInputValidity() {
   palette.setColor(QPalette::Text, Qt::red);
   _filterWidget->setPalette(palette);
   _filterWidget->setToolTip(regex.errorString());
+}
+
+void QSpdLogToolBar::clearCompleterHistory() {
+  QStringListModel *model = static_cast<QStringListModel *>(_completerData);
+  model->setStringList({});
+  saveCompleterHistory();
+}
+
+void QSpdLogToolBar::loadCompleterHistory() {
+  QStringListModel *model = static_cast<QStringListModel *>(_completerData);
+  model->setStringList(QSettings().value("completerHistory").toStringList());
+}
+
+void QSpdLogToolBar::saveCompleterHistory() {
+  QStringListModel *model = static_cast<QStringListModel *>(_completerData);
+  QSettings().setValue("completerHistory", model->stringList());
 }

--- a/src/qspdlog_toolbar.cpp
+++ b/src/qspdlog_toolbar.cpp
@@ -29,7 +29,8 @@ QSpdLogToolBar::QSpdLogToolBar(QWidget *parent)
   connect(_caseAction, &QAction::toggled, this, &QSpdLogToolBar::filterChanged);
   connect(_regexAction, &QAction::toggled, this,
           &QSpdLogToolBar::filterChanged);
-  connect(autoScrollPolicySelection, &QComboBox::currentIndexChanged, this,
+  connect(autoScrollPolicySelection,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &QSpdLogToolBar::autoScrollPolicyChanged);
   connect(this, &QSpdLogToolBar::filterChanged, this,
           &QSpdLogToolBar::checkInputValidity);

--- a/src/qspdlog_toolbar.hpp
+++ b/src/qspdlog_toolbar.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QToolBar>
+#include <qtoolbar>
 
 class QSpdLogToolBar : public QToolBar {
   Q_OBJECT

--- a/src/qspdlog_toolbar.hpp
+++ b/src/qspdlog_toolbar.hpp
@@ -6,6 +6,7 @@ class QWidget;
 class QAction;
 class QCompleter;
 class QAbstractItemModel;
+class QSettings;
 
 class QSpdLogToolBar : public QToolBar {
   Q_OBJECT
@@ -29,10 +30,15 @@ public:
 
   FilteringSettings filteringSettings() const;
   void checkInputValidity();
+  void clearCompleterHistory();
 
 signals:
   void filterChanged();
   void autoScrollPolicyChanged(int index);
+
+private:
+  void loadCompleterHistory();
+  void saveCompleterHistory();
 
 private:
   QWidget *_filterWidget;

--- a/src/qspdlog_toolbar.hpp
+++ b/src/qspdlog_toolbar.hpp
@@ -2,6 +2,11 @@
 
 #include <qtoolbar>
 
+class QWidget;
+class QAction;
+class QCompleter;
+class QAbstractItemModel;
+
 class QSpdLogToolBar : public QToolBar {
   Q_OBJECT
 
@@ -33,4 +38,6 @@ private:
   QWidget *_filterWidget;
   QAction *_caseAction;
   QAction *_regexAction;
+  QAbstractItemModel *_completerData;
+  QCompleter *_completer;
 };


### PR DESCRIPTION
Adds a history feature for search.

With the PR applies, the following features get added to the toolbar:
- the toolbar's search bar gets a history of searched items
- the toolbar's search bar suggests items based on the history
- per each search, the history get's saved in the settings
- per each opening of the toolbar, the history get's loaded from the settings
- a functionality for clearing the history

<img width="404" alt="Screenshot 2022-12-24 at 01 06 44" src="https://user-images.githubusercontent.com/22396275/209405549-74cb331d-fc87-4bd1-b78b-db61bce2cd9e.png">