### PR TITLE
Add Qt::FontRole data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,7 +82,13 @@
 		"queue": "cpp",
 		"semaphore": "cpp",
 		"streambuf": "cpp",
-		"*.rh": "cpp"
+		"*.rh": "cpp",
+		"codecvt": "cpp",
+		"list": "cpp",
+		"map": "cpp",
+		"future": "cpp",
+		"iomanip": "cpp",
+		"cinttypes": "cpp"
 	},
 	"C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
 	"sonarlint.pathToCompileCommands": "${workspaceFolder}/build/compile_commands.json"

--- a/include/qspdlog/qspdlog.hpp
+++ b/include/qspdlog/qspdlog.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QWidget>
 #include <QFont>
+#include <QWidget>
 
 namespace spdlog
 {
@@ -168,8 +168,7 @@ public:
      * font from
      * @return std::optional<QFont> the QFont object or std::nullopt
      */
-    std::optional<QFont> getLoggerFont(std::string_view loggerName
-    ) const;
+    std::optional<QFont> getLoggerFont(std::string_view loggerName) const;
 
     /**
      * @brief Set the policy of the auto-scrolling feature.

--- a/include/qspdlog/qspdlog.hpp
+++ b/include/qspdlog/qspdlog.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QFont>
 
 namespace spdlog
 {
@@ -147,6 +148,27 @@ public:
      * @return std::optional<QBrush> the QBrush object or std::nullopt
      */
     std::optional<QBrush> getLoggerBackground(std::string_view loggerName
+    ) const;
+
+    /**
+     * @brief Set the text QFont for the messages of the corresponding
+     * logger.
+     *
+     * @param std::string_view the name of the logger of which to set the
+     * font
+     * @param std::optional<QFont> the QFont object or std::nullopt
+     */
+    void setLoggerFont(std::string_view loggerName, std::optional<QFont> font);
+
+    /**
+     * @brief Get the text QFont for the messages of the corresponding
+     * logger.
+     *
+     * @param std::string_view the name of the logger of which to get the
+     * font from
+     * @return std::optional<QFont> the QFont object or std::nullopt
+     */
+    std::optional<QFont> getLoggerFont(std::string_view loggerName
     ) const;
 
     /**

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -9,6 +9,7 @@
 #include "qspdlog/qabstract_spdlog_toolbar.hpp"
 #include "qspdlog/qspdlog.hpp"
 #include "spdlog/spdlog.h"
+#include <thread>
 
 std::shared_ptr<spdlog::logger> createLogger(std::string name)
 {

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -5,11 +5,11 @@
 #include <QTimer>
 #include <QToolBar>
 #include <QToolButton>
+#include <thread>
 
 #include "qspdlog/qabstract_spdlog_toolbar.hpp"
 #include "qspdlog/qspdlog.hpp"
 #include "spdlog/spdlog.h"
-#include <thread>
 
 std::shared_ptr<spdlog::logger> createLogger(std::string name)
 {
@@ -77,7 +77,7 @@ void configureToolbar(
         &QAction::triggered,
         [ logger ](bool) {
         // generate 10 messages with random levels
-        for (int i = 0; i < 10; ++i) {
+        for (int i = 0; i < 10; ++i)
             logger->log(
                 static_cast<spdlog::level::level_enum>(
                     rand() % spdlog::level::off
@@ -85,7 +85,6 @@ void configureToolbar(
                 "Message {}",
                 i
             );
-        }
         });
 
     generateMultipleAction->connect(

--- a/src/qspdlog.cpp
+++ b/src/qspdlog.cpp
@@ -118,6 +118,10 @@ void QSpdLog::registerToolbar(QAbstractSpdLogToolBar* toolbarInterface)
         );
 
         _sourceModel->setLoggerForeground(value.loggerName, value.textColor);
+
+        QFont f;
+        f.setBold(value.fontBold);
+        _sourceModel->setLoggerFont(value.loggerName, f);
     });
     connect(
         autoScrollPolicyCombo,
@@ -252,4 +256,18 @@ std::optional<QBrush> QSpdLog::getLoggerBackground(std::string_view loggerName
 ) const
 {
     return _sourceModel->getLoggerBackground(loggerName);
+}
+
+void QSpdLog::setLoggerFont(
+    std::string_view loggerName, std::optional<QFont> font
+) 
+{
+    _sourceModel->setLoggerFont(loggerName, font);
+}
+
+std::optional<QFont> QSpdLog::getLoggerFont(
+    std::string_view loggerName
+) const
+{
+    return _sourceModel->getLoggerFont(loggerName);
 }

--- a/src/qspdlog.cpp
+++ b/src/qspdlog.cpp
@@ -260,14 +260,12 @@ std::optional<QBrush> QSpdLog::getLoggerBackground(std::string_view loggerName
 
 void QSpdLog::setLoggerFont(
     std::string_view loggerName, std::optional<QFont> font
-) 
+)
 {
     _sourceModel->setLoggerFont(loggerName, font);
 }
 
-std::optional<QFont> QSpdLog::getLoggerFont(
-    std::string_view loggerName
-) const
+std::optional<QFont> QSpdLog::getLoggerFont(std::string_view loggerName) const
 {
     return _sourceModel->getLoggerFont(loggerName);
 }

--- a/src/qspdlog_model.cpp
+++ b/src/qspdlog_model.cpp
@@ -2,6 +2,7 @@
 #include <QDateTime>
 #include <QFile>
 #include <QIcon>
+#include <QFont>
 
 #include "qspdlog_model.hpp"
 
@@ -146,6 +147,14 @@ QVariant QSpdLogModel::data(const QModelIndex& index, int role) const
             break;
         }
 
+        case Qt::FontRole: {
+            std::string loggerName = _items[ index.row() ].loggerName;
+            if (_fontMappings.contains(loggerName))
+                return _fontMappings.at(loggerName);
+            
+            break;
+        }
+
         default: {
             break;
         }
@@ -230,6 +239,42 @@ std::optional<QBrush> QSpdLogModel::getLoggerBackground(
 {
     if (_backgroundMappings.contains(std::string(loggerName)))
         return _backgroundMappings.at(std::string(loggerName));
+
+    return std::nullopt;
+}
+
+void QSpdLogModel::setLoggerFont(
+    std::string_view loggerName, std::optional<QFont> font
+)
+{
+    int lastRow = this->rowCount() - 1;
+    if (lastRow < 0)
+        lastRow = 0;
+    int lastColumn = this->columnCount() - 1;
+    if (lastColumn < 0)
+        lastColumn = 0;
+    if (font.has_value()) {
+        _fontMappings[ std::string(loggerName) ] = font.value();
+        emit dataChanged(
+            this->index(0),
+            this->index(lastRow, lastColumn),
+            { Qt::FontRole }
+        );
+    } else if (_fontMappings.contains(std::string(loggerName))) {
+        _fontMappings.erase(std::string(loggerName));
+        emit dataChanged(
+            this->index(0),
+            this->index(lastRow, lastColumn),
+            { Qt::FontRole }
+        );
+    }
+}
+std::optional<QFont> QSpdLogModel::getLoggerFont(
+    std::string_view loggerName
+) const
+{
+    if (_fontMappings.contains(std::string(loggerName)))
+        return _fontMappings.at(std::string(loggerName));
 
     return std::nullopt;
 }

--- a/src/qspdlog_model.cpp
+++ b/src/qspdlog_model.cpp
@@ -1,8 +1,8 @@
 #include <QBrush>
 #include <QDateTime>
 #include <QFile>
-#include <QIcon>
 #include <QFont>
+#include <QIcon>
 
 #include "qspdlog_model.hpp"
 
@@ -151,7 +151,7 @@ QVariant QSpdLogModel::data(const QModelIndex& index, int role) const
             std::string loggerName = _items[ index.row() ].loggerName;
             if (_fontMappings.contains(loggerName))
                 return _fontMappings.at(loggerName);
-            
+
             break;
         }
 
@@ -172,6 +172,7 @@ QVariant QSpdLogModel::headerData(
 
     return QVariant();
 }
+
 void QSpdLogModel::setLoggerForeground(
     std::string_view loggerName, std::optional<QColor> color
 )
@@ -198,6 +199,7 @@ void QSpdLogModel::setLoggerForeground(
         );
     }
 }
+
 std::optional<QColor> QSpdLogModel::getLoggerForeground(
     std::string_view loggerName
 ) const
@@ -207,6 +209,7 @@ std::optional<QColor> QSpdLogModel::getLoggerForeground(
 
     return std::nullopt;
 }
+
 void QSpdLogModel::setLoggerBackground(
     std::string_view loggerName, std::optional<QBrush> brush
 )
@@ -233,6 +236,7 @@ void QSpdLogModel::setLoggerBackground(
         );
     }
 }
+
 std::optional<QBrush> QSpdLogModel::getLoggerBackground(
     std::string_view loggerName
 ) const
@@ -256,21 +260,17 @@ void QSpdLogModel::setLoggerFont(
     if (font.has_value()) {
         _fontMappings[ std::string(loggerName) ] = font.value();
         emit dataChanged(
-            this->index(0),
-            this->index(lastRow, lastColumn),
-            { Qt::FontRole }
+            this->index(0), this->index(lastRow, lastColumn), { Qt::FontRole }
         );
     } else if (_fontMappings.contains(std::string(loggerName))) {
         _fontMappings.erase(std::string(loggerName));
         emit dataChanged(
-            this->index(0),
-            this->index(lastRow, lastColumn),
-            { Qt::FontRole }
+            this->index(0), this->index(lastRow, lastColumn), { Qt::FontRole }
         );
     }
 }
-std::optional<QFont> QSpdLogModel::getLoggerFont(
-    std::string_view loggerName
+
+std::optional<QFont> QSpdLogModel::getLoggerFont(std::string_view loggerName
 ) const
 {
     if (_fontMappings.contains(std::string(loggerName)))

--- a/src/qspdlog_model.hpp
+++ b/src/qspdlog_model.hpp
@@ -3,6 +3,7 @@
 #include <QAbstractListModel>
 #include <deque>
 #include <optional>
+#include <QFont>
 
 class QSpdLogModel : public QAbstractListModel
 {
@@ -32,6 +33,9 @@ public:
     void setLoggerBackground(std::string_view loggerName, std::optional<QBrush> brush);
     std::optional<QBrush> getLoggerBackground(std::string_view loggerName) const;
 
+    void setLoggerFont(std::string_view loggerName, std::optional<QFont> font);
+    std::optional<QFont> getLoggerFont(std::string_view loggerName) const;
+
 #pragma region QAbstractListModel
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -47,4 +51,5 @@ private:
     std::optional<std::size_t> _maxEntries;
     std::map<std::string, QBrush> _backgroundMappings;
     std::map<std::string, QColor> _foregroundMappings;
+    std::map<std::string, QFont> _fontMappings;
 };

--- a/src/qspdlog_style_dialog.cpp
+++ b/src/qspdlog_style_dialog.cpp
@@ -1,7 +1,7 @@
 #include <QBoxLayout>
+#include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QLineEdit>
-#include <QCheckBox>
 
 #include "qspdlog_style_dialog.hpp"
 
@@ -37,7 +37,9 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
         loggerNameEdit,
         &QLineEdit::textChanged,
         this,
-        [ this, backgroundColorEdit, textColorEdit, checkBoxBold ](const QString& name) {
+        [ this, backgroundColorEdit, textColorEdit, checkBoxBold ](
+            const QString& name
+        ) {
         std::string namestdstr = name.toStdString();
         auto bg = _model->getLoggerBackground(namestdstr);
         auto fg = _model->getLoggerForeground(namestdstr);
@@ -51,14 +53,12 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
         if (fg)
             textColorEdit->setText(fg.value().name());
         else
-            backgroundColorEdit->setText("");
+            textColorEdit->setText("");
 
-        if (fnt)
-        {
+        if (fnt) {
             bool isBold = fnt->bold();
             checkBoxBold->setChecked(isBold);
-        }else
-        {
+        } else {
             checkBoxBold->setChecked(false);
         }
         });
@@ -67,7 +67,11 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
         buttonBox,
         &QDialogButtonBox::accepted,
         this,
-        [ this, loggerNameEdit, backgroundColorEdit, textColorEdit, checkBoxBold ]() {
+        [ this,
+          loggerNameEdit,
+          backgroundColorEdit,
+          textColorEdit,
+          checkBoxBold ]() {
         if (!loggerNameEdit->text().isEmpty())
             reject();
 
@@ -82,11 +86,12 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
             _result.textColor = QColor(textColorEdit->text());
         else
             _result.textColor = std::nullopt;
-        
+
         _result.fontBold = checkBoxBold->isChecked();
 
         accept();
         });
+
     connect(buttonBox, &QDialogButtonBox::rejected, this, [ this ]() {
         reject();
     });

--- a/src/qspdlog_style_dialog.cpp
+++ b/src/qspdlog_style_dialog.cpp
@@ -1,6 +1,7 @@
 #include <QBoxLayout>
 #include <QDialogButtonBox>
 #include <QLineEdit>
+#include <QCheckBox>
 
 #include "qspdlog_style_dialog.hpp"
 
@@ -19,10 +20,13 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
     QLineEdit* textColorEdit = new QLineEdit();
     textColorEdit->setPlaceholderText("Text color");
     textColorEdit->setObjectName("textColorEdit");
+    QCheckBox* checkBoxBold = new QCheckBox("Bold");
+    checkBoxBold->setObjectName("checkBoxBold");
 
     layout->addWidget(loggerNameEdit);
     layout->addWidget(backgroundColorEdit);
     layout->addWidget(textColorEdit);
+    layout->addWidget(checkBoxBold);
 
     QDialogButtonBox* buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -33,23 +37,37 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
         loggerNameEdit,
         &QLineEdit::textChanged,
         this,
-        [ this, backgroundColorEdit, textColorEdit ](const QString& name) {
+        [ this, backgroundColorEdit, textColorEdit, checkBoxBold ](const QString& name) {
         std::string namestdstr = name.toStdString();
         auto bg = _model->getLoggerBackground(namestdstr);
         auto fg = _model->getLoggerForeground(namestdstr);
+        auto fnt = _model->getLoggerFont(namestdstr);
 
         if (bg)
             backgroundColorEdit->setText(bg.value().color().name());
+        else
+            backgroundColorEdit->setText("");
 
         if (fg)
             textColorEdit->setText(fg.value().name());
+        else
+            backgroundColorEdit->setText("");
+
+        if (fnt)
+        {
+            bool isBold = fnt->bold();
+            checkBoxBold->setChecked(isBold);
+        }else
+        {
+            checkBoxBold->setChecked(false);
+        }
         });
 
     connect(
         buttonBox,
         &QDialogButtonBox::accepted,
         this,
-        [ this, loggerNameEdit, backgroundColorEdit, textColorEdit ]() {
+        [ this, loggerNameEdit, backgroundColorEdit, textColorEdit, checkBoxBold ]() {
         if (!loggerNameEdit->text().isEmpty())
             reject();
 
@@ -64,6 +82,8 @@ QSpdLogStyleDialog::QSpdLogStyleDialog(QWidget* parent)
             _result.textColor = QColor(textColorEdit->text());
         else
             _result.textColor = std::nullopt;
+        
+        _result.fontBold = checkBoxBold->isChecked();
 
         accept();
         });

--- a/src/qspdlog_style_dialog.hpp
+++ b/src/qspdlog_style_dialog.hpp
@@ -14,6 +14,7 @@ public:
         std::string loggerName;
         std::optional<QColor> backgroundColor;
         std::optional<QColor> textColor;
+        bool fontBold;
     };
 
 public:


### PR DESCRIPTION
This is related to #35 and just adds the ability to change the `Qt::FontRole` for a specific logger. It works just like the background and foreground colors.

I also added a "Bold" checkbox to the toolbar which demonstrates this feature. Unit tests are also included in this PR.

Additionally, I made a small change to the style popup, it resets the `QLineEdit` and `QCheckBox` values if the `std::optional`s are `std::nullopt`.